### PR TITLE
Fire events when trashing and restoring object.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,18 @@ Example:
       parent = aq_parent(aq_inner(context))
       return getSecurityManager().checkPermission('Modify portal content', parent)
 
+
+Events
+~~~~~~
+
+These object events are fired:
+
+- `ftw.trash.interfaces.IBeforeObjectTrashedEvent`: the object will be trashed.
+- `ftw.trash.interfaces.IObjectTrashedEvent`: the object has been trashed.
+- `ftw.trash.interfaces.IBeforeObjectRestoredEvent`: the object will be restored.
+- `ftw.trash.interfaces.IObjectRestoredEvent`: the object has been restored.
+
+
 Internals
 ---------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fire events when trashing and restoring object. [jone]
 
 
 1.0.0 (2018-07-05)

--- a/ftw/trash/events.py
+++ b/ftw/trash/events.py
@@ -1,0 +1,42 @@
+from ftw.trash.interfaces import IBeforeObjectRestoredEvent
+from ftw.trash.interfaces import IBeforeObjectTrashedEvent
+from ftw.trash.interfaces import IObjectRestoredEvent
+from ftw.trash.interfaces import IObjectTrashedEvent
+from zope.component.interfaces import ObjectEvent
+from zope.interface import implementer
+
+
+@implementer(IBeforeObjectTrashedEvent)
+class BeforeObjectTrashedEvent(ObjectEvent):
+    """An object will be trashed.
+    """
+
+    def __init__(self, object):
+        self.object = object
+
+
+@implementer(IObjectTrashedEvent)
+class ObjectTrashedEvent(ObjectEvent):
+    """An object has been trashed.
+    """
+
+    def __init__(self, object):
+        self.object = object
+
+
+@implementer(IBeforeObjectRestoredEvent)
+class BeforeObjectRestoredEvent(ObjectEvent):
+    """An object will be restored.
+    """
+
+    def __init__(self, object):
+        self.object = object
+
+
+@implementer(IObjectRestoredEvent)
+class ObjectRestoredEvent(ObjectEvent):
+    """An object has been restored.
+    """
+
+    def __init__(self, object):
+        self.object = object

--- a/ftw/trash/interfaces.py
+++ b/ftw/trash/interfaces.py
@@ -1,3 +1,4 @@
+from zope.component.interfaces import IObjectEvent
 from zope.interface import Interface
 
 
@@ -15,4 +16,24 @@ class IIsRestoreAllowedAdapter(Interface):
     """The IIsRestoreAllowedAdapter multi adapter decides whether an object can be
     restored or not.
     See the readme for usage details.
+    """
+
+
+class IBeforeObjectTrashedEvent(IObjectEvent):
+    """An object will be trashed.
+    """
+
+
+class IObjectTrashedEvent(IObjectEvent):
+    """An object has been trashed.
+    """
+
+
+class IBeforeObjectRestoredEvent(IObjectEvent):
+    """An object will be restored.
+    """
+
+
+class IObjectRestoredEvent(IObjectEvent):
+    """An object has been restored.
     """

--- a/ftw/trash/testing.py
+++ b/ftw/trash/testing.py
@@ -1,16 +1,16 @@
 from ftw.builder.testing import BUILDER_LAYER
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.configuration import xmlconfig
 
 
 class TrashLayer(PloneSandboxLayer):
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         xmlconfig.string(
@@ -43,7 +43,7 @@ class TrashNotInstalledLayer(PloneSandboxLayer):
     apply patches, but the patches should only change behavior when also the Generic Setup
     profile is installed.
     """
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         xmlconfig.string(


### PR DESCRIPTION
Introduce events before and after trashing and restoring so that other components can integrate easily.