### PR TITLE
Do not intercept link integrity checker.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fire events when trashing and restoring object. [jone]
+- Do not intercept link integrity checker. [jone]
 
 
 1.0.0 (2018-07-05)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -1,5 +1,6 @@
 from ftw.trash.trasher import Trasher
 from ftw.trash.utils import is_trash_profile_installed
+from ftw.trash.utils import within_link_integrity_check
 
 
 def manage_trashObjects(self, ids=None, REQUEST=None):
@@ -14,7 +15,7 @@ def manage_trashObjects(self, ids=None, REQUEST=None):
 
 
 def manage_delObjects(self, ids=None, REQUEST=None):
-    if is_trash_profile_installed():
+    if is_trash_profile_installed() and not within_link_integrity_check():
         return self.manage_trashObjects(ids=ids, REQUEST=REQUEST)
     else:
         return self._old_manage_delObjects(ids=ids, REQUEST=REQUEST)

--- a/ftw/trash/utils.py
+++ b/ftw/trash/utils.py
@@ -1,7 +1,22 @@
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import isLinked
 from zope.component.hooks import getSite
+import inspect
 
 
 def is_trash_profile_installed():
     portal_setup = getToolByName(getSite(), 'portal_setup')
     return portal_setup.getLastVersionForProfile('ftw.trash:default') != 'unknown'
+
+
+def within_link_integrity_check():
+    """Returns True when we are within a link integrity check.
+    """
+    frame = inspect.currentframe()
+    while True:
+        frame = frame.f_back
+        if frame is None:
+            return False
+
+        if frame.f_code == isLinked.func_code:
+            return True


### PR DESCRIPTION
ftw.trash must not interecpt deleting objects within a link integrity check, because the link integrity checker relies on actually deleted objects, which is not compatible with the trash since the trash does not delete the object.

The interception is disabled while within a link integrity stack trace.