### PR TITLE
Respect /view in redirect after restoring a file.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- When restoring a file, redirect to /view so that the file is not downloaded. [jone]
 - Provide a manage_immediatelyDeleteObjects method. [jone]
 - Fix cleaning trash when there is a parent and a child in the trash at once. [jone]
 - Fix and translate error message when trying to restore child of trashed parent. [jone]

--- a/ftw/trash/browser/trash.py
+++ b/ftw/trash/browser/trash.py
@@ -72,7 +72,8 @@ class TrashView(BrowserView):
               mapping={u'title': safe_unicode(obj.Title())}),
             type='info')
 
-        self.request.response.redirect(obj.absolute_url())
+        target_url = obj.restrictedTraverse('@@plone_context_state').view_url()
+        self.request.response.redirect(target_url)
 
     def confirm_clean_trash(self):
         """Show confirmation dialog for cleaning the trash.

--- a/ftw/trash/tests/test_trash_view.py
+++ b/ftw/trash/tests/test_trash_view.py
@@ -89,6 +89,14 @@ class TestTrashView(FunctionalTestCase):
         self.assert_provides(folder, None)
 
     @browsing
+    def test_restore_redirects_to_view_for_files(self, browser):
+        self.grant('Site Administrator')
+        Trasher(create(Builder('file'))).trash()
+        transaction.commit()
+        browser.login().open(view='trash').click_on('Restore')
+        self.assertEquals('http://nohost/plone/file/view', browser.url)
+
+    @browsing
     def test_error_message_when_restore_not_allowed(self, browser):
         self.grant('Site Administrator')
 


### PR DESCRIPTION
When restoring a file, redirect to /view so that the file is not downloaded. This is done by using the Plone plone_context_state view, which doesrespect the `typesUseViewActionInListings` property.