### PR TITLE
Make PloneFormGen aware of trashed objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Patch `Products.PloneFormGen` to make it aware of trashed objects [Nachtalb]
 
 
 1.2.0 (2018-08-16)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -1,3 +1,4 @@
+from ftw.trash.interfaces import ITrashed
 from ftw.trash.trasher import Trasher
 from ftw.trash.utils import called_from_ZMI
 from ftw.trash.utils import is_trash_profile_installed
@@ -50,3 +51,8 @@ def searchResults(self, REQUEST=None, **kw):
         kw['trashed'] = [True, False, None]
 
     return self._old_searchResults(REQUEST, **kw)
+
+
+def _getFieldObjects(self, *args, **kwargs):
+    return filter(lambda obj: not ITrashed.providedBy(obj),
+                  self._old__getFieldObjects(*args, **kwargs))

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -56,3 +56,14 @@ def searchResults(self, REQUEST=None, **kw):
 def _getFieldObjects(self, *args, **kwargs):
     return filter(lambda obj: not ITrashed.providedBy(obj),
                   self._old__getFieldObjects(*args, **kwargs))
+
+
+def getRawActionAdapter(self, *args, **kwargs):
+    adapter_ids = self._old_getRawActionAdapter(*args, **kwargs)
+    adapter_result = []
+
+    for adapter_id in adapter_ids:
+        if not ITrashed.providedBy(self.get(adapter_id)):
+            adapter_result.append(adapter_id)
+
+    return tuple(adapter_result)

--- a/ftw/trash/patches.zcml
+++ b/ftw/trash/patches.zcml
@@ -113,4 +113,16 @@
       order="1100"
       />
 
+  <!-- PLONE FORM GEN -->
+  <configure zcml:condition="installed Products.PloneFormGen">
+    <monkey:patch
+      description="Patch FormFolder._getFieldObjects"
+      class="Products.PloneFormGen.content.form.FormFolder"
+      original="_getFieldObjects"
+      replacement=".patches._getFieldObjects"
+      preserveOriginal="true"
+      order="1100"
+      />
+  </configure>
+
 </configure>

--- a/ftw/trash/patches.zcml
+++ b/ftw/trash/patches.zcml
@@ -123,6 +123,15 @@
       preserveOriginal="true"
       order="1100"
       />
+
+    <monkey:patch
+      description="Patch FormFolder.getRawActionAdapter"
+      class="Products.PloneFormGen.content.form.FormFolder"
+      original="getRawActionAdapter"
+      replacement=".patches.getRawActionAdapter"
+      preserveOriginal="true"
+      order="1100"
+      />
   </configure>
 
 </configure>

--- a/ftw/trash/testing.py
+++ b/ftw/trash/testing.py
@@ -23,10 +23,12 @@ class TrashLayer(PloneSandboxLayer):
             context=configurationContext)
 
         z2.installProduct(app, 'ftw.trash')
+        z2.installProduct(app, 'Products.PloneFormGen')
 
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'ftw.trash:default')
         applyProfile(portal, 'ftw.trash.tests:dxtests')
+        applyProfile(portal, 'Products.PloneFormGen:default')
 
 
 TRASH_FIXTURE = TrashLayer()

--- a/ftw/trash/tests/__init__.py
+++ b/ftw/trash/tests/__init__.py
@@ -85,7 +85,7 @@ def duplicate_with_dexterity(klass):
     (postfixed "Dexterity"), where the "folder" builder is changed to a DX builder
     creating the FTI "dxfolder", which is registered in a Generic Setup test-profile.
 
-    So if you use this decoratior, be aware, that only "Builder('folder')" is replaced
+    So if you use this decorator, be aware, that only "Builder('folder')" is replaced
     with dexterity, all other builders and other code does not change.
     """
 

--- a/ftw/trash/tests/builders.py
+++ b/ftw/trash/tests/builders.py
@@ -1,5 +1,14 @@
+from ftw.builder import builder_registry
 from ftw.builder.dexterity import DexterityBuilder
+from ftw.builder.archetypes import ArchetypesBuilder
 
 
 class DXFolderBuilder(DexterityBuilder):
     portal_type = 'dxfolder'
+
+
+class FormFolderBuilder(ArchetypesBuilder):
+    portal_type = 'FormFolder'
+
+
+builder_registry.register('FormFolder', FormFolderBuilder)

--- a/ftw/trash/tests/test_ploneformgen.py
+++ b/ftw/trash/tests/test_ploneformgen.py
@@ -32,3 +32,17 @@ class TestPloneFormGen(FunctionalTestCase):
 
         browser.reload()
         self.assertFalse(browser.find('Your E-Mail Address'))
+
+    @browsing
+    def test_ploneformgen_field_not_required(self, browser):
+        form_folder = create(Builder('FormFolder'))
+        form_folder.manage_delObjects(['replyto'])
+        transaction.commit()
+
+        browser.login().visit(form_folder)
+        browser.find_form_by_field('Subject').fill({
+            'Subject': 'Foo',
+             'Comments': 'Bar'
+        }).submit()
+
+        self.assertNotIn('This field is required.', browser.css('.fieldErrorBox').text)

--- a/ftw/trash/tests/test_ploneformgen.py
+++ b/ftw/trash/tests/test_ploneformgen.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.trash.interfaces import ITrashed
+from ftw.trash.tests import FunctionalTestCase
+import transaction
+
+
+class TestPloneFormGen(FunctionalTestCase):
+    def setUp(self):
+        super(TestPloneFormGen, self).setUp()
+        self.grant('Manager')
+
+        # Set Missing Property, so mailing wont fail
+        self.portal._updateProperty('email_from_address', 'foo@bar.ch')
+
+    @browsing
+    def test_ploneformgen_removes_trashed_fields(self, browser):
+        form_folder = create(Builder('FormFolder'))
+
+        reply_to = form_folder.get('replyto')
+        self.assertIn(reply_to, form_folder._getFieldObjects())
+
+        browser.login().visit(form_folder)
+        self.assertTrue(browser.find('Your E-Mail Address'))
+
+        form_folder.manage_delObjects([reply_to.id])
+        transaction.commit()
+
+        self.assertTrue(ITrashed.providedBy(reply_to))
+        self.assertNotIn(reply_to, form_folder._getFieldObjects())
+
+        browser.reload()
+        self.assertFalse(browser.find('Your E-Mail Address'))

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ tests_require = [
     'ftw.testing',
     'plone.app.testing',
     'plone.testing',
+    'Products.PloneFormGen < 1.8.0a',
 ]
 
 extras_require = {


### PR DESCRIPTION
Methods Patched:
- `_getFieldObjects` returns the fields for a form
    - Prevents rendering the form field on the frontend
    - Prevents the form from validating the form field

- `getRawActionAdapter` returns the id's of all adapters for a form
    - Prevents the form from running the adapter