### PR TITLE
Clean trash, event if there is not enough permission to delete the actual item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Clean trash, even if there is not enough permission to delete the actual item. [mathias.leimgruber]
 
 
 1.3.0 (2018-12-17)

--- a/ftw/trash/tests/test_trash_view.py
+++ b/ftw/trash/tests/test_trash_view.py
@@ -214,6 +214,23 @@ class TestTrashView(FunctionalTestCase):
         browser.click_on('Clean trash').click_on('Delete')
         self.assertNotIn('parent', self.portal.objectIds())
 
+    @browsing
+    def test_empty_trash_event_if_user_has_insufficient_permissions_on_the_item(self, browser):
+        self.grant('Site Administrator')
+
+        folder = create(Builder('folder').within(create(Builder('folder'))))
+        parent = folder.aq_parent
+        folder_id = folder.getId()
+
+        parent.manage_delObjects([folder_id])
+        folder.manage_permission('Delete portal content', roles=['Manager'], acquire=False)
+        transaction.commit()
+
+        browser.login().open().click_on('Trash')
+        browser.click_on('Clean trash').click_on('Delete')
+
+        self.assertNotIn(folder_id, parent)
+
     @property
     def type_label(self):
         if self.is_dexterity and not IS_PLONE_5:

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,10 @@ setup(
     install_requires=[
         'Plone',
         'collective.deletepermission',
-        'setuptools',
         'ftw.profilehook',
         'ftw.upgrade',
+        'plone.api',
+        'setuptools',
     ],
 
     tests_require=tests_require,


### PR DESCRIPTION
Depending on the WF implementation. 

A Site Admin may not be able to delete certain content. 
Thus if the User has the `clean trash` permission on the root, he should be able to delete trashed items anyway. 