### PR TITLE
Make it possible to delete single items in the trash view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make it possible to delete single items in the trash view. [jone]
 
 
 1.3.1 (2019-04-23)

--- a/ftw/trash/browser/configure.zcml
+++ b/ftw/trash/browser/configure.zcml
@@ -9,6 +9,7 @@
       class=".trash.TrashView"
       permission="ftw.trash.RestoreTrashedContent"
       allowed_attributes="restore
+                          delete_permanently
                           confirm_clean_trash
                           clean_trash"
       />

--- a/ftw/trash/browser/templates/trash.pt
+++ b/ftw/trash/browser/templates/trash.pt
@@ -36,6 +36,15 @@
                 <input type="hidden" name="uuid" tal:attributes="value item/uuid" />
                 <input type="submit" value="Restore" i18n:attributes="value" />
               </form>
+              <form method="POST"
+                    onsubmit="return confirm(this.getAttribute('data_confirm_message'));"
+                    tal:attributes="action string:${request/URL}/delete_permanently"
+                    data_confirm_message="Are you sure that you want to delete this content and its children permanently?"
+                    i18n:attributes="data_confirm_message">
+                <span tal:replace="structure context/@@authenticator/authenticator"/>
+                <input type="hidden" name="uuid" tal:attributes="value item/uuid" />
+                <input type="submit" value="Delete permanently" i18n:attributes="value" />
+              </form>
             </td>
           </tr>
 

--- a/ftw/trash/locales/de/LC_MESSAGES/ftw.trash.po
+++ b/ftw/trash/locales/de/LC_MESSAGES/ftw.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-10 09:03+0000\n"
+"POT-Creation-Date: 2019-07-23 16:30+0000\n"
 "PO-Revision-Date: 2018-07-04 20:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -11,6 +11,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/trash/browser/templates/trash.pt:39
+msgid "Are you sure that you want to delete this content and its children permanently?"
+msgstr "Sind Sie sicher, dass sie diesen Inhalt und dessen Unterinhalte unwiederruflich löschen wollen?"
+
 #: ./ftw/trash/browser/templates/clean-trash-confirmation.pt:12
 msgid "Are you sure you want to permanently delete all objects in the trash?"
 msgstr "Sind Sie sicher, dass sie alle Inhalte im Papierkorb unwiederruflich löschen wollen?"
@@ -19,7 +23,7 @@ msgstr "Sind Sie sicher, dass sie alle Inhalte im Papierkorb unwiederruflich lö
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ./ftw/trash/browser/templates/trash.pt:47
+#: ./ftw/trash/browser/templates/trash.pt:56
 msgid "Clean trash"
 msgstr "Papierkorb leeren"
 
@@ -30,6 +34,10 @@ msgstr "Beim Leeren des Papierkorbs werden alle Inhalte des Papierkorbs und dere
 #: ./ftw/trash/browser/templates/clean-trash-confirmation.pt:23
 msgid "Delete"
 msgstr "Löschen"
+
+#: ./ftw/trash/browser/templates/trash.pt:46
+msgid "Delete permanently"
+msgstr "Definitiv löschen"
 
 #: ./ftw/trash/browser/templates/trash.pt:37
 msgid "Restore"
@@ -48,18 +56,23 @@ msgstr "ftw.trash"
 msgid "ftw.trash: uninstall"
 msgstr "ftw.trash: deinstallieren"
 
+#. Default: "The content \"${title}\" has ben parmanently deleted."
+#: ./ftw/trash/browser/trash.py:101
+msgid "statusmessage_content_permanently_deleted"
+msgstr "Der Inhalt \"${title}\" wurde definitiv gelöscht."
+
 #. Default: "\"${title}\" cannot be restored because the parent container \"${parent}\" is also trashed. You need to restore the parent first."
-#: ./ftw/trash/browser/trash.py:48
+#: ./ftw/trash/browser/trash.py:50
 msgid "statusmessage_content_restore_error_parent_trashed"
 msgstr "\"${title}\" kann nicht wiederhergestellt werden, solange der übergeordnete Inhalt \"${parent}\" auch im Papierkorb ist. Der übergeordnete Inhalt muss zuerst wiederhergestellt werden."
 
 #. Default: "You are not allowed to restore \"${title}\". You may need to change the workflow state of the parent content."
-#: ./ftw/trash/browser/trash.py:59
+#: ./ftw/trash/browser/trash.py:62
 msgid "statusmessage_content_restore_not_allowed"
 msgstr "Sie dürfen \"${title}\" nicht wiederherstellen. Möglicherweise können Sie den Status des übergeordneten Inhalts verändern."
 
 #. Default: "The content \"${title}\" has been restored."
-#: ./ftw/trash/browser/trash.py:68
+#: ./ftw/trash/browser/trash.py:71
 msgid "statusmessage_content_restored"
 msgstr "Der Inhalt \"${title}\" wurde wieder hergestellt."
 

--- a/ftw/trash/locales/ftw.trash.pot
+++ b/ftw/trash/locales/ftw.trash.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-10 09:03+0000\n"
+"POT-Creation-Date: 2019-07-23 16:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,6 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#: ./ftw/trash/browser/templates/trash.pt:39
+msgid "Are you sure that you want to delete this content and its children permanently?"
+msgstr ""
+
 #: ./ftw/trash/browser/templates/clean-trash-confirmation.pt:12
 msgid "Are you sure you want to permanently delete all objects in the trash?"
 msgstr ""
@@ -22,7 +26,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: ./ftw/trash/browser/templates/trash.pt:47
+#: ./ftw/trash/browser/templates/trash.pt:56
 msgid "Clean trash"
 msgstr ""
 
@@ -32,6 +36,10 @@ msgstr ""
 
 #: ./ftw/trash/browser/templates/clean-trash-confirmation.pt:23
 msgid "Delete"
+msgstr ""
+
+#: ./ftw/trash/browser/templates/trash.pt:46
+msgid "Delete permanently"
 msgstr ""
 
 #: ./ftw/trash/browser/templates/trash.pt:37
@@ -51,18 +59,23 @@ msgstr ""
 msgid "ftw.trash: uninstall"
 msgstr ""
 
+#. Default: "The content \"${title}\" has ben parmanently deleted."
+#: ./ftw/trash/browser/trash.py:101
+msgid "statusmessage_content_permanently_deleted"
+msgstr ""
+
 #. Default: "\"${title}\" cannot be restored because the parent container \"${parent}\" is also trashed. You need to restore the parent first."
-#: ./ftw/trash/browser/trash.py:48
+#: ./ftw/trash/browser/trash.py:50
 msgid "statusmessage_content_restore_error_parent_trashed"
 msgstr ""
 
 #. Default: "You are not allowed to restore \"${title}\". You may need to change the workflow state of the parent content."
-#: ./ftw/trash/browser/trash.py:59
+#: ./ftw/trash/browser/trash.py:62
 msgid "statusmessage_content_restore_not_allowed"
 msgstr ""
 
 #. Default: "The content \"${title}\" has been restored."
-#: ./ftw/trash/browser/trash.py:68
+#: ./ftw/trash/browser/trash.py:71
 msgid "statusmessage_content_restored"
 msgstr ""
 


### PR DESCRIPTION
Goal: it should be possible to delete a single content without having to clear the whole trash.
Reason: the content in the trash may block a certain ID which can be disruptive when renaming other content.

<img width="1454" alt="Bildschirmfoto 2019-07-23 um 18 32 58" src="https://user-images.githubusercontent.com/7469/61730017-c7b94780-ad78-11e9-805a-771725bacdfe.png">

<img width="1454" alt="Bildschirmfoto 2019-07-23 um 18 33 02" src="https://user-images.githubusercontent.com/7469/61730005-c38d2a00-ad78-11e9-81a7-bbc70a0b5007.png">
