### PR TITLE
Patch "contentItems" to no longer return trashed content.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,8 @@ Internals
   Restoring children without their deleted parents cannot work since the parent is missing.
 - Trashed content is not moved.
 - The catalog's ``searchResults`` method is patched so that it filters trashed objects by default.
+- The ``contentItems`` method is patched to exclude trashed content.
+  It is used for ``listFolderContents`` and ``getFolderContents``.
 - Trashed content is prevented from beeing published / accessible through the browser unless
   the user has the ``Manager`` role.
 - For restoring content, the permissions ``Restore trashed content`` and ``Add portal content``

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let ``contentItems``, ``listFolderContents`` and ``getFolderContents`` no longer return trashed content. [jone]
 
 
 1.4.1 (2019-07-25)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -5,6 +5,12 @@ from ftw.trash.utils import is_trash_profile_installed
 from ftw.trash.utils import within_link_integrity_check
 
 
+def contentItems(self, filter=None):
+    items = self._old_contentItems(filter=filter)
+    items = [item for item in items if not ITrashed.providedBy(item[1])]
+    return items
+
+
 def manage_trashObjects(self, ids=None, REQUEST=None):
     """Marks objects as trashed.
     """

--- a/ftw/trash/patches.zcml
+++ b/ftw/trash/patches.zcml
@@ -7,6 +7,17 @@
   <include package="collective.deletepermission" />
   <include package="collective.monkeypatcher" />
 
+  <!-- CMFCore -->
+  <monkey:patch
+      description="Patch contentItems"
+      class="Products.CMFCore.PortalFolder.PortalFolderBase"
+      original="contentItems"
+      replacement="ftw.trash.patches.contentItems"
+      preserveOriginal="true"
+      preservedoc="true"
+      order="1100"
+      />
+
   <!-- PLONE SITE ROOT -->
   <monkey:patch
       description="Patch site root manage_trashObjects"

--- a/ftw/trash/tests/test_plone.py
+++ b/ftw/trash/tests/test_plone.py
@@ -1,0 +1,75 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.trash.tests import duplicate_with_dexterity
+from ftw.trash.tests import FunctionalTestCase
+from ftw.trash.trasher import Trasher
+
+
+@duplicate_with_dexterity
+class TestPloneIntegration(FunctionalTestCase):
+
+    def test_folder_objectItems_returns_trashed_content(self):
+        """A folder's objectItems should return trashed content.
+        """
+        self.grant('Contributor')
+        container = create(Builder('folder').titled(u'Container'))
+        foo = create(Builder('folder').titled(u'Foo').within(container))
+        bar = create(Builder('folder').titled(u'Bar').within(container))
+        self.assertEqual([('foo', foo), ('bar', bar)], list(container.objectItems()))
+        Trasher(foo).trash()
+        self.assertEqual([('foo', foo), ('bar', bar)], list(container.objectItems()))
+
+    def test_plone_objectItems_returns_trashed_content(self):
+        """A Plone site's objectItems should return trashed content.
+        """
+        self.grant('Contributor')
+        foo = create(Builder('folder').titled(u'Foo'))
+        self.assertIn(('foo', foo), list(self.portal.objectItems()))
+        Trasher(foo).trash()
+        self.assertIn(('foo', foo), list(self.portal.objectItems()))
+
+    def test_folder_contentItems_does_not_return_trashed_content(self):
+        """A folder's contentItems should not return trashed content.
+        """
+        self.grant('Contributor')
+        container = create(Builder('folder').titled(u'Container'))
+        foo = create(Builder('folder').titled(u'Foo').within(container))
+        bar = create(Builder('folder').titled(u'Bar').within(container))
+        self.assertEqual([('foo', foo), ('bar', bar)], container.contentItems())
+        Trasher(foo).trash()
+        self.assertEqual([('bar', bar)], container.contentItems())
+
+    def test_plone_contentItems_does_not_return_trashed_content(self):
+        """A Plone site's contentItems should not return trashed content.
+        """
+        self.grant('Contributor')
+        foo = create(Builder('folder').titled(u'Foo'))
+        self.assertIn(('foo', foo), self.portal.contentItems())
+        Trasher(foo).trash()
+        self.assertNotIn(('foo', foo), self.portal.contentItems())
+
+    def test_listFolderContents_does_not_return_trashed_content(self):
+        """A folder's listFolderContents should not return trashed content.
+        """
+        self.grant('Contributor')
+        container = create(Builder('folder').titled(u'Container'))
+        foo = create(Builder('folder').titled(u'Foo').within(container))
+        bar = create(Builder('folder').titled(u'Bar').within(container))
+        self.assertEqual([foo, bar], container.listFolderContents())
+        Trasher(foo).trash()
+        self.assertEqual([bar], container.listFolderContents())
+
+    def test_getFolderContents_does_not_return_trashed_content(self):
+        """A folder's getFolderContents should not return trashed content.
+        """
+        self.grant('Contributor')
+        container = create(Builder('folder').titled(u'Container'))
+        foo = create(Builder('folder').titled(u'Foo').within(container))
+        bar = create(Builder('folder').titled(u'Bar').within(container))
+        self.assertEqual(
+            [foo, bar],
+            [brain.getObject() for brain in container.getFolderContents()])
+        Trasher(foo).trash()
+        self.assertEqual(
+            [bar],
+            [brain.getObject() for brain in container.getFolderContents()])


### PR DESCRIPTION
The ``contentItems`` is used for other methods such as ``listFolderContents`` and ``getFolderContents``. We do not want those methods to include trashed content as they are used within Plone and within our addons. We are not patching the underlying ``objectItems`` though as it probably would make the trashed content disappear from ZMI and harder to restore etc.