### PR TITLE
Do not check security recursively.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not check security recursively when trashing in order to have
+  the same behavior as standard Plone. [jone]
 
 
 1.5.0 (2019-10-02)

--- a/ftw/trash/tests/test_deletion.py
+++ b/ftw/trash/tests/test_deletion.py
@@ -88,9 +88,10 @@ class TestDeletion(FunctionalTestCase):
             # Our test user with role Manager is not allowed to delete the child because
             # we have limited the permissions to "Contributor".
             parent.manage_delObjects([child.getId()])
-            self.assertIn(child.getId(), parent.objectIds())
-            self.assert_provides(parent, None)
-            self.assert_provides(child, None)
+
+        self.assertIn(child.getId(), parent.objectIds())
+        self.assert_provides(parent, None)
+        self.assert_provides(child, None)
 
         user = create(Builder('user').with_roles('Contributor', on=parent))
         with self.user(user):

--- a/ftw/trash/tests/test_deletion.py
+++ b/ftw/trash/tests/test_deletion.py
@@ -100,6 +100,36 @@ class TestDeletion(FunctionalTestCase):
             self.assert_provides(parent, None)
             self.assert_provides(child, IRestorable, ITrashed)
 
+    def test_manage_delObjects_does_not_check_permissions_recursively(self):
+        """The standard behavior of Plone is that it only checks the delete permission on the
+        content selected for deletion by the user. The children of the selected content is
+        not checked for the delete permission.
+        ftw.trash should not change the default behavior of Plone regarding security checks.
+        """
+        self.grant('Manager')
+        container = create(Builder('folder'))
+        parent = create(Builder('folder').within(container))
+        child = create(Builder('folder').within(parent))
+        child.manage_permission('Delete portal content', roles=[], acquire=False)
+        self.assertIn(child.getId(), parent.objectIds())
+        self.assert_provides(container, None)
+        self.assert_provides(parent, None)
+        self.assert_provides(child, None)
+
+        with self.assertRaises(Unauthorized):
+            # The child should not be deletable, as nobody has the "Delete portal content" permission.
+            parent.manage_delObjects([child.getId()])
+
+        self.assert_provides(container, None)
+        self.assert_provides(parent, None)
+        self.assert_provides(child, None)
+
+        # The parent is deletable and also deletes the child implicitly.
+        container.manage_delObjects([parent.getId()])
+        self.assert_provides(container, None)
+        self.assert_provides(parent, IRestorable, ITrashed)
+        self.assert_provides(child, ITrashed)
+
     def test_confirmation_dialog_link_integrity_checker_should_actually_delete_the_object(self):
         """The confirmation dialog deletes the object within a later rolled-back savepoint
         in order to detect broken links.

--- a/ftw/trash/trasher.py
+++ b/ftw/trash/trasher.py
@@ -28,6 +28,7 @@ class Trasher(object):
         self.context = context
 
     def trash(self):
+        protect_del_objects(aq_parent(aq_inner(self.context)), self.context.getId())
         notify(BeforeObjectTrashedEvent(self.context))
         self._trash_recursive(self.context, is_root=True)
         notify(ObjectTrashedEvent(self.context))
@@ -55,7 +56,6 @@ class Trasher(object):
         notify(ObjectRestoredEvent(self.context))
 
     def _trash_recursive(self, obj, is_root=False):
-        protect_del_objects(aq_parent(aq_inner(obj)), obj.getId())
         alsoProvides(obj, ITrashed)
         if is_root:
             alsoProvides(obj, IRestorable)


### PR DESCRIPTION
The standard behavior of Plone is that it only checks the delete permission on the content selected for deletion by the user. The children of the selected content is not checked for the delete permission.

`ftw.trash` should not change the default behavior of Plone regarding security checks. Therefore we change the security checks to no longer being executed recursively.
