### PR TITLE
Implement context manager, which allows us to disable the trash functionality temporary 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,21 @@ The patches are applied on the site root, on DX- and on AT-folders when ``ftw.tr
 is installed in the path.
 For the methods to work properly, the Generic Setup profile must be installed as well.
 
+
+Temporary disable trash feature
+--------------------------------
+
+You can either set the env variable ``DISABLE_FTW_TRASH`` manually, or use the provided context manager.
+
+.. code::python
+
+    from ftw.trash.utils import temporary_disable_trash
+
+    with temporary_disable_trash():
+        self.portal.manage_delObjects([container1.getId()])
+
+
+
 Manipulate condition for restoring
 ==================================
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce ``temporary_disable_trash`` context manager. [mathias.leimgruber]
+
 
 
 1.5.1 (2019-10-18)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -1,6 +1,7 @@
 from ftw.trash.interfaces import ITrashed
 from ftw.trash.trasher import Trasher
 from ftw.trash.utils import called_from_ZMI
+from ftw.trash.utils import is_trash_disabled
 from ftw.trash.utils import is_trash_profile_installed
 from ftw.trash.utils import within_link_integrity_check
 
@@ -25,7 +26,8 @@ def manage_trashObjects(self, ids=None, REQUEST=None):
 def manage_delObjects(self, ids=None, REQUEST=None):
     if is_trash_profile_installed() and \
        not within_link_integrity_check() and \
-       not called_from_ZMI(REQUEST):
+       not called_from_ZMI(REQUEST) and \
+       not is_trash_disabled():
         return self.manage_trashObjects(ids=ids, REQUEST=REQUEST)
     else:
         return self.manage_immediatelyDeleteObjects(ids=ids, REQUEST=REQUEST)

--- a/ftw/trash/tests/__init__.py
+++ b/ftw/trash/tests/__init__.py
@@ -12,7 +12,7 @@ from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from Products.CMFCore.utils import getToolByName
-from unittest2 import TestCase
+from unittest import TestCase
 import sys
 import transaction
 

--- a/ftw/trash/tests/test_deletion.py
+++ b/ftw/trash/tests/test_deletion.py
@@ -8,6 +8,7 @@ from ftw.trash.interfaces import IRestorable
 from ftw.trash.interfaces import ITrashed
 from ftw.trash.tests import duplicate_with_dexterity
 from ftw.trash.tests import FunctionalTestCase
+from ftw.trash.utils import temporary_disable_trash
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import isLinked
@@ -162,3 +163,17 @@ class TestDeletion(FunctionalTestCase):
         self.assertIn(folder_id, parent.objectIds())
         parent.manage_immediatelyDeleteObjects(folder_id)
         self.assertNotIn(folder_id, parent.objectIds())
+
+    def test_trash_immediately_if_env_var_is_there(self):
+        self.grant('Manager')
+
+        container1 = create(Builder('folder'))
+        container_id = container1.getId()
+
+        with temporary_disable_trash():
+            self.portal.manage_delObjects([container1.getId()])
+            self.assertNotIn(container_id, self.portal.objectIds())
+
+        container2 = create(Builder('folder'))
+        self.portal.manage_delObjects([container2.getId()])
+        self.assert_provides(container2, IRestorable, ITrashed)

--- a/ftw/trash/tests/test_uninstall.py
+++ b/ftw/trash/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
 from ftw.testing.genericsetup import apply_generic_setup_layer
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer

--- a/ftw/trash/tests/test_utils.py
+++ b/ftw/trash/tests/test_utils.py
@@ -2,7 +2,7 @@ from ftw.trash.testing import TRASH_NOT_INSTALLED_FUNCTIONAL
 from ftw.trash.tests import FunctionalTestCase
 from ftw.trash.utils import filter_children_in_paths
 from ftw.trash.utils import is_trash_profile_installed
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestUtilsWhenInstalled(FunctionalTestCase):

--- a/ftw/trash/utils.py
+++ b/ftw/trash/utils.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import isLinked
 from zope.component.hooks import getSite
@@ -8,6 +9,20 @@ import os
 def is_trash_profile_installed():
     portal_setup = getToolByName(getSite(), 'portal_setup')
     return portal_setup.getLastVersionForProfile('ftw.trash:default') != 'unknown'
+
+
+def is_trash_disabled():
+    return os.environ.get('DISABLE_FTW_TRASH', None) == 'true'
+
+
+@contextmanager
+def temporary_disable_trash():
+
+    os.environ['DISABLE_FTW_TRASH'] = 'true'
+    try:
+        yield
+    finally:
+        del os.environ['DISABLE_FTW_TRASH']
 
 
 def within_link_integrity_check():


### PR DESCRIPTION
This is for example useful in upgrade steps. 

It's implemented with a env variable, so It could also disabled generally

Additionally:
I als removed unittest2 module dependency. 