### PR TITLE
Disable trash when migrating Plone site.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable trash when migrating Plone site. [jone]
 
 
 1.6.0 (2019-12-04)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -1,6 +1,7 @@
 from ftw.trash.interfaces import ITrashed
 from ftw.trash.trasher import Trasher
 from ftw.trash.utils import called_from_ZMI
+from ftw.trash.utils import is_migrating_plone_site
 from ftw.trash.utils import is_trash_disabled
 from ftw.trash.utils import is_trash_profile_installed
 from ftw.trash.utils import within_link_integrity_check
@@ -27,7 +28,8 @@ def manage_delObjects(self, ids=None, REQUEST=None):
     if is_trash_profile_installed() and \
        not within_link_integrity_check() and \
        not called_from_ZMI(REQUEST) and \
-       not is_trash_disabled():
+       not is_trash_disabled() and \
+       not is_migrating_plone_site(self.REQUEST):
         return self.manage_trashObjects(ids=ids, REQUEST=REQUEST)
     else:
         return self.manage_immediatelyDeleteObjects(ids=ids, REQUEST=REQUEST)

--- a/ftw/trash/utils.py
+++ b/ftw/trash/utils.py
@@ -16,7 +16,7 @@ def is_trash_disabled():
 
 
 def is_migrating_plone_site(request):
-    """Detects whether we are in a request which migrats Plone to a new version.
+    """Detects whether we are in a request which migrates Plone to a new version.
     In this case we want to disable the trash, because it may cause problems
     e.g. when deleting tools.
     """

--- a/ftw/trash/utils.py
+++ b/ftw/trash/utils.py
@@ -15,6 +15,17 @@ def is_trash_disabled():
     return os.environ.get('DISABLE_FTW_TRASH', None) == 'true'
 
 
+def is_migrating_plone_site(request):
+    """Detects whether we are in a request which migrats Plone to a new version.
+    In this case we want to disable the trash, because it may cause problems
+    e.g. when deleting tools.
+    """
+    return request.steps and request.steps[-1] in (
+        '@@plone-upgrade',  # ZMI TTW
+        'plone_upgrade',  # ftw.upgrade
+    )
+
+
 @contextmanager
 def temporary_disable_trash():
 


### PR DESCRIPTION
When migrating to a newer Plone version, having the trash active can cause problems, e.g. when tools (`portal_*`) are removed.