### PR TITLE
Fix bug when migrating Plone site.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix bug when migrating Plone site. [jone]
 
 
 1.7.0 (2019-12-05)

--- a/ftw/trash/patches.py
+++ b/ftw/trash/patches.py
@@ -29,7 +29,7 @@ def manage_delObjects(self, ids=None, REQUEST=None):
        not within_link_integrity_check() and \
        not called_from_ZMI(REQUEST) and \
        not is_trash_disabled() and \
-       not is_migrating_plone_site(self.REQUEST):
+       not is_migrating_plone_site(self):
         return self.manage_trashObjects(ids=ids, REQUEST=REQUEST)
     else:
         return self.manage_immediatelyDeleteObjects(ids=ids, REQUEST=REQUEST)

--- a/ftw/trash/utils.py
+++ b/ftw/trash/utils.py
@@ -15,11 +15,17 @@ def is_trash_disabled():
     return os.environ.get('DISABLE_FTW_TRASH', None) == 'true'
 
 
-def is_migrating_plone_site(request):
+def is_migrating_plone_site(obj):
     """Detects whether we are in a request which migrates Plone to a new version.
     In this case we want to disable the trash, because it may cause problems
     e.g. when deleting tools.
     """
+    # obj may not be acquisition wrapped and may not have a request.
+    # Fall back to Plone site.
+    request = getattr(obj, 'REQUEST', None)
+    if not request:
+        request = getSite().REQUEST
+
     return request.steps and request.steps[-1] in (
         '@@plone-upgrade',  # ZMI TTW
         'plone_upgrade',  # ftw.upgrade


### PR DESCRIPTION
The problem is that in a Plone migration things are deleted from the Plone site, but the Plone site is not acquisition wrapped.