### PR TITLE
Fix hidden action buttons on the trash view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stop trash items with long paths from hiding action buttons on the trash view. [djowett-ftw]
 
 
 1.7.2 (2019-12-09)

--- a/ftw/trash/browser/templates/trash.pt
+++ b/ftw/trash/browser/templates/trash.pt
@@ -6,6 +6,14 @@
       metal:use-macro="context/main_template/macros/master"
       i18n:domain="ftw.trash">
 
+  <metal:block fill-slot="style_slot">
+    <style>
+      table.listing td div {
+        word-break: break-word;
+      }
+    </style>
+  </metal:block>
+
   <div metal:fill-slot="main">
     <metal:main-macro define-macro="main">
 


### PR DESCRIPTION
Which occurs when trash items with long paths make the table overflow underneath right hand portlets.
    Fixes https://github.com/4teamwork/izug.organisation/issues/1764