### PR TITLE
Only sheck IItem based objects for trashed interfaces.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.7.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Only sheck IItem based objects for trashed interfaces. [mathias.leimgruber]
 
 
 1.7.3 (2020-01-07)

--- a/ftw/trash/subscribers.py
+++ b/ftw/trash/subscribers.py
@@ -1,13 +1,15 @@
 from AccessControl import getSecurityManager
-from ftw.trash import _
-from ftw.trash.interfaces import ITrashed
+from OFS.interfaces import IItem
 from Products.CMFPlone.utils import safe_unicode
 from Products.statusmessages.interfaces import IStatusMessage
+from ftw.trash import _
+from ftw.trash.interfaces import ITrashed
 from zExceptions import NotFound
 
 
 def prevent_accessing_trashed_content_after_traversal(event):
-    context = event.request.PARENTS[0]
+    context = filter(lambda item: IItem.providedBy(item), event.request.PARENTS)[0]
+
     if not ITrashed.providedBy(context):
         return
 

--- a/ftw/trash/tests/test_traversing.py
+++ b/ftw/trash/tests/test_traversing.py
@@ -50,3 +50,18 @@ class TestTraversing(FunctionalTestCase):
         browser.open(folder)
 
         statusmessages.assert_message('The content "Fancy Folder" is trashed.')
+
+    @browsing
+    def test_trashed_download_view_not_accessible(self, browser):
+        self.grant('Contributor')
+        folder = create(Builder('folder'))
+        file_ = create(Builder('file').within(folder).with_dummy_content())
+
+        browser.login()
+        browser.open(file_.absolute_url() + '/@@download/file/test.txt')
+
+        Trasher(folder).trash()
+        transaction.commit()
+
+        with browser.expect_http_error(404):
+            browser.open(file_.absolute_url() + '/@@download/file/test.txt')


### PR DESCRIPTION
This disallows for example file downloads of trashed files.
--> https://plone/folder/file/@@download/file/file.txt